### PR TITLE
Catch plstore keys being written outside plstore

### DIFF
--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -159,6 +159,7 @@ from PLIST if non-nil.  The return value is intended to be stored in plstore."
         (plstore (plstore-open oauth2-auto-plstore)))
     (unwind-protect
         (prog1 plist
+          (advice-add #'insert :before #'oauth2-auto--insert-break-on-secret-entries)
           (plstore-put plstore id nil plist)
           ;; Seems like we occasionally end up with a killed buffer in PLSTORE - reinitialize it in that case.
           (if (buffer-live-p (plstore--get-buffer plstore))
@@ -167,7 +168,8 @@ from PLIST if non-nil.  The return value is intended to be stored in plstore."
                 (puthash id plist oauth2-auto--plstore-cache))
             (plstore-close plstore)
             (oauth2-auto--plstore-write username provider plist)))
-      (plstore-close plstore))))
+      (plstore-close plstore)
+      (advice-remove #'insert #'oauth2-auto--insert-break-on-secret-entries))))
 
 (defun oauth2-auto--insert-break-on-secret-entries (&rest args)
   "Break if trying to insert secret entries outside of plstore buffer.
@@ -183,7 +185,6 @@ fix https://github.com/rhaps0dy/emacs-oauth2-auto/issues/6."
        (backtrace-frames 'oauth2-auto--plstore-write))
     (error "BUG: Attempted to write ‘oauth2-auto’ keys to %s, not ‘oauth2-auto-plstore’ (%s).  Please report to https://github.com/rhaps0dy/emacs-oauth2-auto/issues/6."
            (buffer-file-name) oauth2-auto-plstore)))
-(advice-add #'insert :before #'oauth2-auto--insert-break-on-secret-entries)
 
 (defun oauth2-auto--plstore-read (username provider)
   "Read the data for USERNAME and PROVIDER from the cache, else from plstore.

--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -169,6 +169,22 @@ from PLIST if non-nil.  The return value is intended to be stored in plstore."
             (oauth2-auto--plstore-write username provider plist)))
       (plstore-close plstore))))
 
+(defun oauth2-auto--insert-break-on-secret-entries (&rest args)
+  "Break if trying to insert secret entries outside of plstore buffer.
+ARGS are those passed to ‘insert’.
+
+This function is added as before advice to ‘insert’ to attempt to reproduce and
+fix https://github.com/rhaps0dy/emacs-oauth2-auto/issues/6."
+  (when
+      (and
+       (stringp (buffer-file-name))
+       (not (file-equal-p oauth2-auto-plstore (buffer-file-name)))
+       (equal ";;; secret entries\n" (nth 0 args))
+       (backtrace-frames 'oauth2-auto--plstore-write))
+    (error "BUG: Attempted to write ‘oauth2-auto’ keys to %s, not ‘oauth2-auto-plstore’ (%s).  Please report to https://github.com/rhaps0dy/emacs-oauth2-auto/issues/6."
+           (buffer-file-name) oauth2-auto-plstore)))
+(advice-add #'insert :before #'oauth2-auto--insert-break-on-secret-entries)
+
 (defun oauth2-auto--plstore-read (username provider)
   "Read the data for USERNAME and PROVIDER from the cache, else from plstore.
 Cache data if a miss occurs."

--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -161,11 +161,12 @@ from PLIST if non-nil.  The return value is intended to be stored in plstore."
         (prog1 plist
           (plstore-put plstore id nil plist)
           ;; Seems like we occasionally end up with a killed buffer in PLSTORE - reinitialize it in that case.
-          (unless (buffer-live-p (plstore--get-buffer plstore))
-           (setq plstore (plstore-open oauth2-auto-plstore))
-           (plstore-put plstore id nil plist))
-          (plstore-save plstore)
-          (puthash id plist oauth2-auto--plstore-cache))
+          (if (buffer-live-p (plstore--get-buffer plstore))
+              (progn
+                (plstore-save plstore)
+                (puthash id plist oauth2-auto--plstore-cache))
+            (plstore-close plstore)
+            (oauth2-auto--plstore-write username provider plist)))
       (plstore-close plstore))))
 
 (defun oauth2-auto--plstore-read (username provider)


### PR DESCRIPTION
For background see https://github.com/rhaps0dy/emacs-oauth2-auto/issues/6.

This attempts to reopen the plstore buffer when this condition is detected in `oauth2-auto--plstore-write`. In addition, we add advice to `insert` to detect if we attempt to write this string to a file that's not `oauth2-auto-plstore`, and raise an error in that case.

This may ultimately be an upstream issue, but until it is fixed, we should try to avoid having our keys written outside of plstore.