### PR TITLE
fix copyright statement

### DIFF
--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -1,6 +1,6 @@
 ;;; oauth2-auto.el --- Automatically refreshing OAuth 2.0 tokens -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2011-2021 Free Software Foundation, Inc
+;; Copyright (C) 2011-2021 Adrià Garriga-Alonso, Robert Irelan
 
 ;; Author: Adrià Garriga-Alonso <adria.garriga@gmail.com>
 ;; URL: https://github.com/rhaps0dy/emacs-oauth2-auto


### PR DESCRIPTION
- seems unlikely that this has been [assigned to the FSF](https://www.gnu.org/licenses/why-assign)
- introduced with [first commit](https://github.com/telotortium/emacs-oauth2-auto/commit/178ca24b0c61c5a9fb286d13e98626978992eda5#diff-3c11c8a0c1f1ace4d5eb5d1bd981417eaaa91d99768dcfc964be2a497bca5a4aR3)