### PR TITLE
Add manual authentication mode for OAuth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The following customizable variables let you change the behaviour of `oauth2-aut
 - `oauth2-auto-additional-providers-alist`: extra providers that `oauth2-auto`
   doesn't include by default, who also follow the OAuth2 protocol. This alist
   should follow the format from the value in `oauth2-auto--default-providers`.
+- `oauth2-auto-manually-auth`: if non-nil, prevents automatic browser launching.
+  Instead, displays the authorization URL and prompts the user to manually copy
+  the authorization code. Useful in headless environments or when automatic
+  browser opening is problematic.
 
 ## Alerts
 
@@ -126,6 +130,27 @@ stdout.
   (princ (oauth2-auto-access-token-sync username (intern provider)))
   (princ "\n"))
 ```
+
+
+## Manual Authentication Mode
+
+By default, `oauth2-auto` automatically opens your browser for OAuth authentication. However, you can enable manual authentication mode by setting:
+
+```emacs-lisp
+(setq oauth2-auto-manually-auth t)
+```
+
+In manual mode:
+1. Instead of opening a browser automatically, `oauth2-auto` will display the authorization URL
+2. You manually visit this URL in your browser
+3. After completing authentication, the browser will redirect to a 404 page (this is normal behavior since the callback URL is mandatory but not actually serving content)
+4. Copy the authorization code from the `code` parameter in the URL of the 404 page
+5. Paste the code when prompted by Emacs
+
+This is useful in scenarios such as:
+- Running Emacs in a headless environment (servers, containers)
+- Systems where automatic browser launching doesn't work properly
+- Security-conscious setups where you want explicit control over browser interaction
 
 ## Privacy policy
 

--- a/oauth2-auto.el
+++ b/oauth2-auto.el
@@ -75,6 +75,11 @@
   :group 'oauth2-auto
   :type 'alist)
 
+(defcustom oauth2-auto-manually-auth nil
+  "If non-nil, not launch browser automatically."
+  :group 'oauth2-auto
+  :type 'boolean)
+
 (defun oauth2-auto--default-providers ()
   "Default OAuth2 providers."
   (let ((ms-oauth2-url (concat "https://login.microsoftonline.com/"
@@ -395,8 +400,13 @@ INPUT is the raw HTTP request."
       (error msg)
       nil))))
 
-
 (aio-defun oauth2-auto--browser-request (provider url-key data-keys extra-alist &optional quiet)
+           (if oauth2-auto-manually-auth
+               (aio-await (oauth2-auto--browser-request-manually provider url-key data-keys extra-alist quiet))
+             (aio-await (oauth2-auto--browser-request-auto provider url-key data-keys extra-alist quiet))))
+
+
+(aio-defun oauth2-auto--browser-request-auto (provider url-key data-keys extra-alist &optional quiet)
   "Open browser for the OAuth2 PROVIDER.
 Browser is opened at url and parameters given by taking URL-KEY and DATA-KEYS
 from the data of the PROVIDER, and adding EXTRA-ALIST.  Then we listen to the
@@ -446,6 +456,38 @@ If QUIET is non-nil, suppress alerts."
           (cons redirect-uri-elt response-alist))
       ; Always kill server-proc
       (delete-process server-proc))))
+
+(aio-defun oauth2-auto--browser-request-manually (provider url-key data-keys extra-alist &optional quiet)
+           "Open browser for the OAuth2 PROVIDER.
+Instead of opening browser, display the authorization URL and wait for user to input the code.
+Browser URL is constructed from url and parameters given by taking URL-KEY and DATA-KEYS
+from the data of the PROVIDER, and adding EXTRA-ALIST.
+
+If QUIET is non-nil, suppress alerts."
+           (let* ((redirect-uri "http://localhost:8080")
+                  (redirect-uri-elt (cons 'redirect_uri redirect-uri))
+                  (very-extra-alist (cons redirect-uri-elt extra-alist))
+                  (provider-info (oauth2-auto--provider-info provider))
+                  (data-alist (oauth2-auto--craft-request-alist
+                               provider-info data-keys very-extra-alist))
+                  (data (oauth2-auto--urlify-request data-alist))
+                  (url (cdr (assoc url-key provider-info)))
+                  (auth-url (concat url "?" data)))
+
+             ;; Instead of opening browser, show URL and wait for code
+             (unless quiet
+               (alert (format "Please visit this URL to authorize:\n%s\n\nAfter authorization, copy the 'code' parameter from the redirect URL and paste it below:"
+                              auth-url)
+                      :title "Emacs OAuth2 login"
+                      :category 'oauth2-auto))
+
+             ;; Wait for user to input the code
+             (let ((code (read-string (format "Please visit this URL to authorize:\n%s\n\nAfter authorization, copy the code from the redirect URL and paste it here.\nEnter authorization code: " auth-url))))
+               ;; return the response, with the 'redirect_uri
+               (cons redirect-uri-elt
+                     (list (cons 'code code)
+                           (cons 'redirect_uri redirect-uri)
+                           (cons 'state (cdr (assoc 'state data-alist))))))))
 
 (defconst oauth2-auto--url-unreserved
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXY0123456789-_"


### PR DESCRIPTION
# Add Manual Authentication Mode for OAuth2

## Summary

This PR introduces a manual authentication mode for `oauth2-auto` that allows users to authenticate without automatic browser launching. This addresses scenarios where automatic browser opening is problematic or impossible.

### Key Changes

- **New customizable variable**: `oauth2-auto-manually-auth` - when set to `t`, disables automatic browser launching
- **Manual authentication flow**: Instead of opening browser automatically, displays authorization URL and prompts user to manually copy the authorization code
- **Refactored browser request handling**: Split `oauth2-auto--browser-request` into separate auto and manual variants
- **Comprehensive documentation**: Updated README.md with detailed instructions for manual authentication mode

## Use Cases

This feature is particularly useful for:

- **Headless environments**: Servers, containers, or remote systems without GUI
- **Systems with browser launching issues**: Environments where `browse-url` doesn't work properly  

## How It Works

### Manual Authentication Flow

1. User sets `(setq oauth2-auto-manually-auth t)`
2. When authentication is needed, system displays authorization URL
3. User manually visits URL in their preferred browser
4. After OAuth approval, browser redirects to a 404 page (expected behavior)
5. User copies the `code` parameter from the 404 page URL
6. User pastes the code when prompted by Emacs
7. Authentication completes normally

### Technical Implementation

- `oauth2-auto--browser-request` now routes to either auto or manual variant based on the setting
- `oauth2-auto--browser-request-manually` handles the manual flow with user prompts
- Uses a fixed redirect URI (`http://localhost:8080`) since no local server is running
- Maintains compatibility with existing automatic authentication flow

## Documentation

Added comprehensive documentation to README.md including:
- Configuration instructions
- Step-by-step manual authentication process
- Clear explanation of the expected 404 page behavior
- Use case examples and scenarios

## Breaking Changes

None. This is a purely additive feature that defaults to the existing automatic behavior.